### PR TITLE
[feat.] Added support for custom symbols for Items

### DIFF
--- a/src/controls/SearchControl.ts
+++ b/src/controls/SearchControl.ts
@@ -6,7 +6,14 @@
  * Purpose: allow quick map navigation / zoom to named geo-referenced objects.
  */
 
-import {type ControlPosition, Evented, type IControl, Map as MapLibreMap, Marker} from 'maplibre-gl';
+import {
+    type ControlPosition,
+    Evented,
+    type IControl,
+    Map as MapLibreMap,
+    Marker,
+    type MarkerOptions
+} from 'maplibre-gl';
 import {DataProvider, DataProviderEventType} from '../dataProviders/DataProvider';
 import type {NamedGeoReferencedObject} from '../enitities/NamedGeoReferencedObject';
 import {icon} from '@fortawesome/fontawesome-svg-core';
@@ -19,7 +26,7 @@ import {useControl} from '@vis.gl/react-maplibre';
 
 import './css/search.scss';
 import {useEffect} from 'react';
-import {ApplicationLogger} from "../ApplicationLogger.ts";
+import {ApplicationLogger} from '../ApplicationLogger.ts';
 
 /**
  * SearchControl provides a lightweight search UI for NamedGeoReferencedObject entries.
@@ -53,7 +60,13 @@ export function ReactSearchControl(props: ReactSearchControlProps): null {
             if (map) {
                 ApplicationLogger.info('Showing updated item on map:' + item.getName(), {service: 'SearchControl'});
                 if (!shownItems.has(item.getId() as string)) {
-                    const marker = new Marker()
+                    const markerOptions: MarkerOptions = {};
+                    if (item.getIconElement()){
+                        const container = document.createElement('div');
+                        container.appendChild(item.getIconElement({width: 50, height: 50}) as HTMLElement);
+                        markerOptions.element = container;
+                    }
+                    const marker = new Marker(markerOptions)
                         .setLngLat([item.getLongitude(), item.getLatitude()])
                         .addTo(map);
                     shownItems.set(item.getId() as string, marker);
@@ -61,6 +74,12 @@ export function ReactSearchControl(props: ReactSearchControlProps): null {
                     const marker = shownItems.get(item.getId() as string);
                     if (marker) {
                         marker.setLngLat([item.getLongitude(), item.getLatitude()]);
+                        if (item.getIconElement()){
+                            if (marker._element.children.length > 0) {
+                                marker._element.children[0].remove();
+                            }
+                            marker._element.appendChild(item.getIconElement({width: 50, height: 50}) as HTMLElement);
+                        }
                     }
                 }
             }

--- a/src/enitities/NamedGeoReferencedObject.ts
+++ b/src/enitities/NamedGeoReferencedObject.ts
@@ -8,6 +8,7 @@
 
 import type {TaktischesZeichen} from 'taktische-zeichen-core/dist/types/types';
 import {type DBRecord, Entity} from './Entity.ts';
+import {erzeugeTaktischesZeichen} from 'taktische-zeichen-core';
 
 export interface INamedGeoReferencedObject {
     id?: string;
@@ -40,6 +41,7 @@ export class NamedGeoReferencedObject extends Entity {
         this.showOnMap = data.showOnMap || false;
         this.groupId = data.groupId as string | null;
         this.symbol = data.symbol || null;
+
     }
 
     public static of(data: DBRecord): NamedGeoReferencedObject {
@@ -50,7 +52,8 @@ export class NamedGeoReferencedObject extends Entity {
             name: data.name as string,
             zoomLevel: data.zoomLevel !== undefined ? Number(data.zoomLevel) : undefined,
             showOnMap: Boolean(data.show_on_map),
-            groupId: data.group_id as string | undefined
+            groupId: data.group_id as string | undefined,
+            symbol: data.symbol ? (data.symbol as TaktischesZeichen) : undefined,
         });
     }
 
@@ -66,7 +69,32 @@ export class NamedGeoReferencedObject extends Entity {
             zoomLevel: this.zoomLevel || 0,
             group_id: this.groupId || null,
             show_on_map: this.showOnMap || false,
+            symbol: this.symbol ? JSON.stringify(this.symbol) : null,
         };
+    }
+
+
+    public getIconElement(size?: { height: number, width: number }): HTMLElement | undefined {
+        if (!this.symbol) {
+            return undefined;
+        }
+        const tz = erzeugeTaktischesZeichen(this.symbol);
+        if (!tz.dataUrl) {
+            return undefined;
+        }
+        const img = document.createElement('img');
+        img.src = tz.dataUrl;
+        if (size) {
+            img.width = size.width;
+            img.height = size.height;
+        } else {
+            img.width = 32;
+            img.height = 32;
+        }
+
+        const container = document.createElement('div');
+        container.appendChild(img);
+        return container;
     }
 
     public getId(): string | null {


### PR DESCRIPTION
This pull request enhances the display of map markers for geo-referenced objects by supporting custom icons and improves the handling of symbol data in the `NamedGeoReferencedObject` entity. The main changes include adding a method to generate icon elements from tactical symbols, updating marker creation logic to use these icons, and ensuring symbol data is properly serialized and deserialized.

**Map marker display improvements:**

* Added a `getIconElement` method to `NamedGeoReferencedObject` that generates an HTML element for the object's tactical symbol, allowing markers to display custom icons.
* Updated the marker creation and update logic in `ReactSearchControl` to use the new icon element if available, ensuring that markers on the map reflect the associated symbol visually.

**Symbol data handling enhancements:**

* Modified `NamedGeoReferencedObject` to support storing and retrieving the `symbol` property, including serialization to and from JSON for persistence. 
* Imported the `erzeugeTaktischesZeichen` function from `taktische-zeichen-core` to facilitate symbol rendering.